### PR TITLE
Watch for DNS events and register containers in .weave.local with weaveDNS

### DIFF
--- a/plugin/driver/dns.go
+++ b/plugin/driver/dns.go
@@ -1,0 +1,55 @@
+package driver
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func (d *dockerer) registerWithDNS(ID string, fqdn string, ip string) error {
+	dnsip, err := d.getContainerBridgeIP(WeaveDNSContainer)
+	if err != nil {
+		return fmt.Errorf("nameserver not available: %s", err)
+	}
+	data := url.Values{}
+	data.Add("fqdn", fqdn)
+
+	req, err := http.NewRequest("PUT", fmt.Sprintf("http://%s:6785/name/%s/%s", dnsip, ID, ip), strings.NewReader(data.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	cl := &http.Client{}
+	res, err := cl.Do(req)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("non-OK status from nameserver: %d", res.StatusCode)
+	}
+	return nil
+}
+
+func (d *dockerer) deregisterWithDNS(ID string, ip string) error {
+	dnsip, err := d.getContainerBridgeIP(WeaveDNSContainer)
+	if err != nil {
+		return fmt.Errorf("nameserver not available: %s", err)
+	}
+
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s:6785/name/%s/%s", dnsip, ID, ip), nil)
+	if err != nil {
+		return err
+	}
+
+	cl := &http.Client{}
+	res, err := cl.Do(req)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("non-OK status from nameserver: %d", res.StatusCode)
+	}
+	return nil
+}

--- a/plugin/driver/docker.go
+++ b/plugin/driver/docker.go
@@ -1,0 +1,23 @@
+package driver
+
+import (
+	"github.com/fsouza/go-dockerclient"
+	. "github.com/weaveworks/weave/common"
+)
+
+type dockerer struct {
+	client *docker.Client
+}
+
+func (d *dockerer) getContainerBridgeIP(nameOrID string) (string, error) {
+	Debug.Printf("Getting IP for container %s", nameOrID)
+	info, err := d.InspectContainer(nameOrID)
+	if err != nil {
+		return "", err
+	}
+	return info.NetworkSettings.IPAddress, nil
+}
+
+func (d *dockerer) InspectContainer(nameOrId string) (*docker.Container, error) {
+	return d.client.InspectContainer(nameOrId)
+}

--- a/plugin/driver/driver.go
+++ b/plugin/driver/driver.go
@@ -7,10 +7,8 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/docker/libnetwork/types"
 
@@ -22,10 +20,9 @@ import (
 )
 
 const (
-	MethodReceiver    = "NetworkDriver"
-	WeaveContainer    = "weave"
-	WeaveBridge       = "weave"
-	WeaveDNSContainer = "weavedns"
+	MethodReceiver = "NetworkDriver"
+	WeaveContainer = "weave"
+	WeaveBridge    = "weave"
 )
 
 type Driver interface {
@@ -33,11 +30,11 @@ type Driver interface {
 }
 
 type driver struct {
+	dockerer
 	version    string
 	network    string
 	confDir    string
 	nameserver string
-	client     *docker.Client
 	watcher    Watcher
 }
 
@@ -58,9 +55,11 @@ func New(version string, nameserver string, confDir string) (Driver, error) {
 	}
 
 	return &driver{
+		dockerer: dockerer{
+			client: client,
+		},
 		version:    version,
 		nameserver: nameserver,
-		client:     client,
 		confDir:    confDir,
 		watcher:    watcher,
 	}, nil
@@ -248,18 +247,7 @@ func (driver *driver) createEndpoint(w http.ResponseWriter, r *http.Request) {
 		Interfaces: []*iface{respIface},
 	}
 
-	Debug.Printf("Create: %+v", &resp)
 	objectResponse(w, resp)
-
-	domainname, ok := create.Options["io.docker.network.domainname"]
-	if ok && domainname.(string) == "weave.local" {
-		hostname := create.Options["io.docker.network.hostname"]
-		fqdn := fmt.Sprintf("%s.%s", hostname, domainname)
-		if err := driver.registerWithDNS(endID, fqdn, ip); err != nil {
-			Warning.Printf("unable to register with DNS: %s", err)
-		}
-	}
-
 	Info.Printf("Create endpoint %s %+v", endID, resp)
 }
 
@@ -276,9 +264,6 @@ func (driver *driver) deleteEndpoint(w http.ResponseWriter, r *http.Request) {
 	}
 	Debug.Printf("Delete endpoint request: %+v", &delete)
 	emptyResponse(w)
-	if err := driver.deregisterWithDNS(delete.EndpointID); err != nil {
-		Warning.Printf("unable to deregister with DNS: %s", err)
-	}
 	if err := driver.releaseIP(delete.EndpointID); err != nil {
 		Warning.Printf("error releasing IP: %s", err)
 	}
@@ -423,15 +408,6 @@ func vethPair(suffix string) *netlink.Veth {
 	}
 }
 
-func (driver *driver) getContainerBridgeIP(nameOrID string) (string, error) {
-	Debug.Printf("Getting IP for container %s", nameOrID)
-	info, err := driver.client.InspectContainer(nameOrID)
-	if err != nil {
-		return "", err
-	}
-	return info.NetworkSettings.IPAddress, nil
-}
-
 func (driver *driver) resolvConfPath() string {
 	return filepath.Join(driver.confDir, "resolv.conf")
 }
@@ -494,56 +470,4 @@ func makeMac(ip net.IP) string {
 	hw[1] = 0x42
 	copy(hw[2:], ip.To4())
 	return hw.String()
-}
-
-func (driver *driver) registerWithDNS(endpointID string, fqdn string, ip *net.IPNet) error {
-	dnsip, err := driver.getContainerBridgeIP(WeaveDNSContainer)
-	if err != nil {
-		return fmt.Errorf("nameserver not available: %s", err)
-	}
-	data := url.Values{}
-	data.Add("fqdn", fqdn)
-
-	req, err := http.NewRequest("PUT", fmt.Sprintf("http://%s:6785/name/%s/%s", dnsip, endpointID, ip.IP.String()), strings.NewReader(data.Encode()))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	cl := &http.Client{}
-	res, err := cl.Do(req)
-	if err != nil {
-		return err
-	}
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("non-OK status from nameserver: %d", res.StatusCode)
-	}
-	return nil
-}
-
-func (driver *driver) deregisterWithDNS(endpointID string) error {
-	dnsip, err := driver.getContainerBridgeIP(WeaveDNSContainer)
-	if err != nil {
-		return fmt.Errorf("nameserver not available: %s", err)
-	}
-
-	ip, err := driver.ipamOp(endpointID, "GET")
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s:6785/name/%s/%s", dnsip, endpointID, ip.IP.String()), nil)
-	if err != nil {
-		return err
-	}
-
-	cl := &http.Client{}
-	res, err := cl.Do(req)
-	if err != nil {
-		return err
-	}
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("non-OK status from nameserver: %d", res.StatusCode)
-	}
-	return nil
 }

--- a/plugin/driver/ipam.go
+++ b/plugin/driver/ipam.go
@@ -1,0 +1,74 @@
+package driver
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+
+	. "github.com/weaveworks/weave/common"
+)
+
+func (d *dockerer) ipamOp(ID string, op string) (*net.IPNet, error) {
+	weaveip, err := d.getContainerBridgeIP(WeaveContainer)
+	Debug.Printf("IPAM operation %s for %s", op, ID)
+	if err != nil {
+		return nil, err
+	}
+
+	var res *http.Response
+	url := fmt.Sprintf("http://%s:6784/ip/%s", weaveip, ID)
+	if op == "POST" {
+		res, err = http.Post(url, "", nil)
+	} else if op == "GET" {
+		res, err = http.Get(url)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received status %d from IPAM", res.StatusCode)
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	ip, ipnet, err := net.ParseCIDR(string(body))
+	if err == nil {
+		ipnet.IP = ip
+	}
+	return ipnet, err
+}
+
+// returns an IP for the ID given, allocating a fresh one if necessary
+func (d *dockerer) allocateIP(ID string) (*net.IPNet, error) {
+	return d.ipamOp(ID, "POST")
+}
+
+// returns an IP for the ID given, or nil if one has not been
+// allocated
+func (d *dockerer) lookupIP(ID string) (*net.IPNet, error) {
+	return d.ipamOp(ID, "GET")
+}
+
+// release an IP which is no longer needed
+func (d *dockerer) releaseIP(ID string) error {
+	weaveip, err := d.getContainerBridgeIP(WeaveContainer)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s:6784/ip/%s", weaveip, ID), nil)
+	if err != nil {
+		return err
+	}
+	cl := &http.Client{}
+	res, err := cl.Do(req)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected HTTP status code from IP release: %d", res.StatusCode)
+	}
+	return nil
+}

--- a/plugin/driver/watcher.go
+++ b/plugin/driver/watcher.go
@@ -2,9 +2,6 @@ package driver
 
 import (
 	"fmt"
-	"net/http"
-	"net/url"
-	"strings"
 
 	"github.com/fsouza/go-dockerclient"
 	. "github.com/weaveworks/weave/common"
@@ -94,53 +91,4 @@ func (w *watcher) ContainerDied(id string) {
 			Warning.Printf("unable to deregister with weaveDNS: %s", err)
 		}
 	}
-}
-
-// -----
-
-func (watcher *watcher) registerWithDNS(ID string, fqdn string, ip string) error {
-	dnsip, err := watcher.getContainerBridgeIP(WeaveDNSContainer)
-	if err != nil {
-		return fmt.Errorf("nameserver not available: %s", err)
-	}
-	data := url.Values{}
-	data.Add("fqdn", fqdn)
-
-	req, err := http.NewRequest("PUT", fmt.Sprintf("http://%s:6785/name/%s/%s", dnsip, ID, ip), strings.NewReader(data.Encode()))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	cl := &http.Client{}
-	res, err := cl.Do(req)
-	if err != nil {
-		return err
-	}
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("non-OK status from nameserver: %d", res.StatusCode)
-	}
-	return nil
-}
-
-func (watcher *watcher) deregisterWithDNS(ID string, ip string) error {
-	dnsip, err := watcher.getContainerBridgeIP(WeaveDNSContainer)
-	if err != nil {
-		return fmt.Errorf("nameserver not available: %s", err)
-	}
-
-	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s:6785/name/%s/%s", dnsip, ID, ip), nil)
-	if err != nil {
-		return err
-	}
-
-	cl := &http.Client{}
-	res, err := cl.Do(req)
-	if err != nil {
-		return err
-	}
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("non-OK status from nameserver: %d", res.StatusCode)
-	}
-	return nil
 }

--- a/plugin/driver/watcher.go
+++ b/plugin/driver/watcher.go
@@ -1,0 +1,58 @@
+package driver
+
+import (
+	"github.com/fsouza/go-dockerclient"
+	. "github.com/weaveworks/weave/common"
+)
+
+type watcher struct {
+	client   *docker.Client
+	networks map[string]bool
+	events   chan *docker.APIEvents
+}
+
+type Watcher interface {
+	WatchNetwork(uuid string)
+	UnwatchNetwork(uuid string)
+}
+
+func NewWatcher(client *docker.Client) (Watcher, error) {
+	w := &watcher{
+		client:   client,
+		networks: make(map[string]bool),
+		events:   make(chan *docker.APIEvents),
+	}
+	err := client.AddEventListener(w.events)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		for event := range w.events {
+			switch event.Status {
+			case "start":
+				w.ContainerStart(event.ID)
+			case "die":
+				w.ContainerDied(event.ID)
+			}
+		}
+	}()
+
+	return w, nil
+}
+
+func (w *watcher) WatchNetwork(uuid string) {
+	w.networks[uuid] = true
+}
+
+func (w *watcher) UnwatchNetwork(uuid string) {
+	delete(w.networks, uuid)
+}
+
+func (w *watcher) ContainerStart(id string) {
+	Debug.Printf("Container started %s", id)
+}
+
+func (w *watcher) ContainerDied(id string) {
+	Debug.Printf("Container died %s", id)
+}

--- a/plugin/driver/watcher.go
+++ b/plugin/driver/watcher.go
@@ -1,12 +1,22 @@
 package driver
 
 import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
 	"github.com/fsouza/go-dockerclient"
 	. "github.com/weaveworks/weave/common"
 )
 
+const (
+	WeaveDNSContainer = "weavedns"
+	WeaveDomain       = "weave.local"
+)
+
 type watcher struct {
-	client   *docker.Client
+	dockerer
 	networks map[string]bool
 	events   chan *docker.APIEvents
 }
@@ -18,7 +28,9 @@ type Watcher interface {
 
 func NewWatcher(client *docker.Client) (Watcher, error) {
 	w := &watcher{
-		client:   client,
+		dockerer: dockerer{
+			client: client,
+		},
 		networks: make(map[string]bool),
 		events:   make(chan *docker.APIEvents),
 	}
@@ -42,17 +54,93 @@ func NewWatcher(client *docker.Client) (Watcher, error) {
 }
 
 func (w *watcher) WatchNetwork(uuid string) {
+	Debug.Printf("Watch network %s", uuid)
 	w.networks[uuid] = true
 }
 
 func (w *watcher) UnwatchNetwork(uuid string) {
+	Debug.Printf("Unwatch network %s", uuid)
 	delete(w.networks, uuid)
 }
 
 func (w *watcher) ContainerStart(id string) {
 	Debug.Printf("Container started %s", id)
+	info, err := w.InspectContainer(id)
+	if err != nil {
+		Warning.Printf("error inspecting container: %s", err)
+		return
+	}
+	// FIXME: check that it's on our network; but, the docker client lib doesn't know about .NetworkID
+	if info.Config.Domainname == WeaveDomain {
+		// one of ours
+		ip := info.NetworkSettings.IPAddress
+		fqdn := fmt.Sprintf("%s.%s", info.Config.Hostname, info.Config.Domainname)
+		if err := w.registerWithDNS(id, fqdn, ip); err != nil {
+			Warning.Printf("unable to register with weaveDNS: %s", err)
+		}
+	}
 }
 
 func (w *watcher) ContainerDied(id string) {
 	Debug.Printf("Container died %s", id)
+	info, err := w.InspectContainer(id)
+	if err != nil {
+		Warning.Printf("error inspecting container: %s", err)
+		return
+	}
+	if info.Config.Domainname == WeaveDomain {
+		ip := info.NetworkSettings.IPAddress
+		if err := w.deregisterWithDNS(id, ip); err != nil {
+			Warning.Printf("unable to deregister with weaveDNS: %s", err)
+		}
+	}
+}
+
+// -----
+
+func (watcher *watcher) registerWithDNS(ID string, fqdn string, ip string) error {
+	dnsip, err := watcher.getContainerBridgeIP(WeaveDNSContainer)
+	if err != nil {
+		return fmt.Errorf("nameserver not available: %s", err)
+	}
+	data := url.Values{}
+	data.Add("fqdn", fqdn)
+
+	req, err := http.NewRequest("PUT", fmt.Sprintf("http://%s:6785/name/%s/%s", dnsip, ID, ip), strings.NewReader(data.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	cl := &http.Client{}
+	res, err := cl.Do(req)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("non-OK status from nameserver: %d", res.StatusCode)
+	}
+	return nil
+}
+
+func (watcher *watcher) deregisterWithDNS(ID string, ip string) error {
+	dnsip, err := watcher.getContainerBridgeIP(WeaveDNSContainer)
+	if err != nil {
+		return fmt.Errorf("nameserver not available: %s", err)
+	}
+
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s:6785/name/%s/%s", dnsip, ID, ip), nil)
+	if err != nil {
+		return err
+	}
+
+	cl := &http.Client{}
+	res, err := cl.Do(req)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("non-OK status from nameserver: %d", res.StatusCode)
+	}
+	return nil
 }

--- a/plugin/run.sh
+++ b/plugin/run.sh
@@ -20,9 +20,9 @@ echo Run weave
 weaveexec launch -iprange 10.20.0.0/16 $WEAVE_ARGS
 
 echo Run weaveDNS
-weaveexec launch-dns 10.254.254.1/24 $WEAVE_DNS_ARGS
+weaveexec launch-dns 10.254.254.1/24 --watch=false $WEAVE_DNS_ARGS
 
-echo Give weaveDNS a stable, local IP
+echo Make weaved containers routable from weaveDNS
 WEAVEDNS_PID=$(docker inspect --format='{{ .State.Pid }}' weavedns)
 [ ! -d /var/run/netns ] && sudo mkdir -p /var/run/netns
 sudo ln -s /proc/$WEAVEDNS_PID/ns/net /var/run/netns/$WEAVEDNS_PID


### PR DESCRIPTION
This works around not being told by libnetwork about hostnames, in a simple way. It doesn't account for endpoints being added post-hoc, just containers starting with a weave endpoint (or at least, containers with a hostname in ".weave.local").
