### PR TITLE
Work with weave fast datapath (openvswitch) bridge.

### DIFF
--- a/plugin/driver/driver.go
+++ b/plugin/driver/driver.go
@@ -26,9 +26,10 @@ type driver struct {
 	version    string
 	nameserver string
 	watcher    Watcher
+	scope      string
 }
 
-func New(version string, nameserver string) (skel.Driver, error) {
+func New(version, nameserver, scope string) (skel.Driver, error) {
 	client, err := docker.NewClient("unix:///var/run/docker.sock")
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to docker: %s", err)
@@ -46,16 +47,16 @@ func New(version string, nameserver string) (skel.Driver, error) {
 		nameserver: nameserver,
 		version:    version,
 		watcher:    watcher,
+		scope:      scope,
 	}, nil
 }
 
 // === protocol handlers
 
-var caps = &api.GetCapabilityResponse{
-	Scope: "global",
-}
-
 func (driver *driver) GetCapabilities() (*api.GetCapabilityResponse, error) {
+	var caps = &api.GetCapabilityResponse{
+		Scope: driver.scope,
+	}
 	Log.Debugf("Get capabilities: responded with %+v", caps)
 	return caps, nil
 }

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -21,12 +21,14 @@ func main() {
 		address     string
 		nameserver  string
 		debug       bool
+		scope       string
 	)
 
 	flag.BoolVar(&justVersion, "version", false, "print version and exit")
 	flag.BoolVar(&debug, "debug", false, "output debugging info to stderr")
 	flag.StringVar(&address, "socket", "/run/docker/plugins/weave.sock", "socket on which to listen")
 	flag.StringVar(&nameserver, "nameserver", "", "nameserver to provide to containers")
+	flag.StringVar(&scope, "scope", "global", "plugin scope (local or global)")
 
 	flag.Parse()
 
@@ -40,7 +42,7 @@ func main() {
 	}
 
 	var d skel.Driver
-	d, err := driver.New(version, nameserver)
+	d, err := driver.New(version, nameserver, scope)
 	if err != nil {
 		Log.Fatalf("unable to create driver: %s", err)
 	}


### PR DESCRIPTION
Patterned after what the `weave` script does when in FDP mode, except we can call the code directly rather than running the weave router binary.

Needs https://github.com/weaveworks/weave/pull/1665 to extract that code to the `weave/common/odp` package
