### PR TITLE
Support weave script running against non-standard docker unix sockets.

### DIFF
--- a/plugin/driver/driver.go
+++ b/plugin/driver/driver.go
@@ -28,8 +28,8 @@ type driver struct {
 	watcher    Watcher
 }
 
-func New(version string, nameserver string) (skel.Driver, error) {
-	client, err := docker.NewClient("unix:///var/run/docker.sock")
+func New(socket, version string, nameserver string) (skel.Driver, error) {
+	client, err := docker.NewClient(socket)
 	if err != nil {
 		return nil, errorf("could not connect to docker: %s", err)
 	}

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -39,8 +39,13 @@ func main() {
 
 	Log.Println("Weave plugin", version, "Command line options:", os.Args)
 
+	dockerSocket := "unix:///var/run/docker.sock"
+	if os.Getenv("DOCKER_HOST") != "" {
+		dockerSocket = os.Getenv("DOCKER_HOST")
+	}
+
 	var d skel.Driver
-	d, err := driver.New(version, nameserver)
+	d, err := driver.New(dockerSocket, version, nameserver)
 	if err != nil {
 		Log.Fatalf("unable to create driver: %s", err)
 	}


### PR DESCRIPTION
Brings plugin up-to-date with changes in https://github.com/weaveworks/weave/pull/1689
