### PR TITLE
Remove some old code from plugin

### DIFF
--- a/plugin/driver/driver.go
+++ b/plugin/driver/driver.go
@@ -21,10 +21,8 @@ const (
 )
 
 type driver struct {
-	dockerer
 	version    string
 	nameserver string
-	watcher    Watcher
 }
 
 func New(version string, nameserver string) (skel.Driver, error) {
@@ -33,18 +31,14 @@ func New(version string, nameserver string) (skel.Driver, error) {
 		return nil, errorf("could not connect to docker: %s", err)
 	}
 
-	watcher, err := NewWatcher(client)
+	_, err = NewWatcher(client)
 	if err != nil {
 		return nil, err
 	}
 
 	return &driver{
-		dockerer: dockerer{
-			client: client,
-		},
 		nameserver: nameserver,
 		version:    version,
-		watcher:    watcher,
 	}, nil
 }
 
@@ -66,14 +60,12 @@ func (driver *driver) GetCapabilities() (*api.GetCapabilityResponse, error) {
 
 func (driver *driver) CreateNetwork(create *api.CreateNetworkRequest) error {
 	Log.Debugf("Create network request %+v", create)
-	driver.watcher.WatchNetwork(create.NetworkID)
 	Log.Infof("Create network %s", create.NetworkID)
 	return nil
 }
 
 func (driver *driver) DeleteNetwork(delete *api.DeleteNetworkRequest) error {
 	Log.Debugf("Delete network request: %+v", delete)
-	driver.watcher.UnwatchNetwork(delete.NetworkID)
 	Log.Infof("Destroy network %s", delete.NetworkID)
 	return nil
 }

--- a/plugin/driver/watcher.go
+++ b/plugin/driver/watcher.go
@@ -20,8 +20,6 @@ type watcher struct {
 }
 
 type Watcher interface {
-	WatchNetwork(uuid string)
-	UnwatchNetwork(uuid string)
 }
 
 func NewWatcher(client *docker.Client) (Watcher, error) {
@@ -49,16 +47,6 @@ func NewWatcher(client *docker.Client) (Watcher, error) {
 	}()
 
 	return w, nil
-}
-
-func (w *watcher) WatchNetwork(uuid string) {
-	Log.Debugf("Watch network %s", uuid)
-	w.networks[uuid] = true
-}
-
-func (w *watcher) UnwatchNetwork(uuid string) {
-	Log.Debugf("Unwatch network %s", uuid)
-	delete(w.networks, uuid)
 }
 
 func (w *watcher) ContainerStart(id string) {


### PR DESCRIPTION
The code to call ipam from `CreateEndpoint` relates to an earlier version of the interface, and is never called now.

The corresponding code in `DeleteEndpoint` is called every time, which produces an error message in the logs.

The `WatchNetwork` stuff isn't doing anything.
